### PR TITLE
Address UnicodeDecodeError in IMAPlibLoggerAdapter

### DIFF
--- a/imapclient/imapclient.py
+++ b/imapclient/imapclient.py
@@ -1858,15 +1858,12 @@ class IMAPlibLoggerAdapter(LoggerAdapter):
     """Adapter preventing IMAP secrets from going to the logging facility."""
 
     def process(self, msg, kwargs):
-        # Fix a case where UTF-8 encoded bytes reach the logger.
-        if isinstance(msg, bytes):
-            msg = msg.decode('utf-8')
-
-        for command in ("LOGIN", "AUTHENTICATE"):
-            if msg.startswith(">") and command in msg:
-                msg_start = msg.split(command)[0]
-                msg = "{}{} **REDACTED**".format(msg_start, command)
-                break
+        if isinstance(msg, text_type):
+            for command in ("LOGIN", "AUTHENTICATE"):
+                if msg.startswith(">") and command in msg:
+                    msg_start = msg.split(command)[0]
+                    msg = "{}{} **REDACTED**".format(msg_start, command)
+                    break
         return super(IMAPlibLoggerAdapter, self).process(
             msg, kwargs
         )

--- a/imapclient/imapclient.py
+++ b/imapclient/imapclient.py
@@ -1858,11 +1858,14 @@ class IMAPlibLoggerAdapter(LoggerAdapter):
     """Adapter preventing IMAP secrets from going to the logging facility."""
 
     def process(self, msg, kwargs):
-        for command in ("LOGIN", "AUTHENTICATE"):
-            if msg.startswith(">") and command in msg:
-                msg_start = msg.split(command)[0]
-                msg = "{}{} **REDACTED**".format(msg_start, command)
-                break
+        try:
+            for command in ("LOGIN", "AUTHENTICATE"):
+                if msg.startswith(">") and command in msg:
+                    msg_start = msg.split(command)[0]
+                    msg = "{}{} **REDACTED**".format(msg_start, command)
+                    break
+        except UnicodeDecodeError:
+            pass
         return super(IMAPlibLoggerAdapter, self).process(
             msg, kwargs
         )

--- a/imapclient/imapclient.py
+++ b/imapclient/imapclient.py
@@ -1858,8 +1858,8 @@ class IMAPlibLoggerAdapter(LoggerAdapter):
     """Adapter preventing IMAP secrets from going to the logging facility."""
 
     def process(self, msg, kwargs):
-        # Fix a case in Python2 where UTF-8 encoded bytes reach the logger.
-        if not PY3 and isinstance(msg, bytes):
+        # Fix a case where UTF-8 encoded bytes reach the logger.
+        if isinstance(msg, bytes):
             msg = msg.decode('utf-8')
 
         for command in ("LOGIN", "AUTHENTICATE"):


### PR DESCRIPTION
There is a small chance some encoded bytes wil reach
`IMAPlibLoggerAdapter` which Python 2 will fail to decode as ascii.
These cases should not be the "LOGIN" or "AUTHENTICATE" lines the
adapter is trying to redact, so it is OK to pass these on to the `super`
call.